### PR TITLE
[BE] 리액트 배포를 위한 스크립트 작성

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,18 @@
 - Jenny(wjddnjswjd12 ; 정원정12 영어로)
 - Kyle(hayoung123)
 
+## 배포 링크
+
+https://todolist.pyro-squad.com/
+
+## 웹 프론트 배포
+
+리액트 앱을 서버에 배포할 때는 아래의 쉘 커맨드를 활용한다.
+
+```sh
+sh ./backend/front-deploy.sh
+```
+
 ## 브랜치 정책
 
 작업은 feature 브랜치에서 한 후에, dev 브랜치로 PR 을 보내서 머지한다.

--- a/backend/front-deploy.sh
+++ b/backend/front-deploy.sh
@@ -1,0 +1,4 @@
+cd ./frontend/todo-frontend
+yarn build
+aws s3 sync ./build s3://www.pyro.io
+aws cloudfront create-invalidation --distribution-id EX5MW4IXVFXEA --paths / /index.html /error.html /service-worker.js /manifest.json /favicon.ico


### PR DESCRIPTION
AWS 에 S3 + Route53 + CloudFront 로 리액트 SPA 를 정적으로 배포 가능하도록 인프라를 설정 후,
프로젝트의 루트에서 쉘 스크립트로 배포가 가능하도록 했습니다.

https://todolist.pyro-squad.com/

실제 배포가 완료된 도메인 입니다. HTTPS 를 적용하기 위해 삽질을 좀 했습니다.